### PR TITLE
#5 feat: spring security 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 

--- a/src/main/java/choorai/excuseme/global/config/SecurityConfig.java
+++ b/src/main/java/choorai/excuseme/global/config/SecurityConfig.java
@@ -1,0 +1,22 @@
+package choorai.excuseme.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.httpBasic(configurer -> configurer.disable());
+        http.csrf(configurer -> configurer.disable());
+        http.formLogin(configurer -> configurer.disable());
+        http.sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}


### PR DESCRIPTION
Spring Security 설정했습니다.

TMI를 달아두자면
이전에는 WebSecurityConfigurerAdapter를 상속받아서 오버라이딩 하는 형태였는데,
버전이 올라가면서 위 클래스는 deprecated 되었고, 컴포넌트화를 지향하게 바꼈다고 하네요!
그래서 모두 Bean으로 등록하게 하면 됩니다.

그리고 과거 http.httpBasic().disable() 같이 메서드 체이닝 방식이었는데 이것 또한 deprecated되고
람다형태로 집어넣게 바뀌었네요. 
참고해주시면 되겠습니다!