### PR TITLE
#3 feat: actuator 추가 및 Security "actuator/**" permit 나머지 URL 인증 필요하게 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/java/choorai/excuseme/global/config/SecurityConfig.java
+++ b/src/main/java/choorai/excuseme/global/config/SecurityConfig.java
@@ -17,6 +17,10 @@ public class SecurityConfig {
         http.csrf(configurer -> configurer.disable());
         http.formLogin(configurer -> configurer.disable());
         http.sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(configurer ->
+                configurer.requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().authenticated());
         return http.build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,11 @@ logging:
           descriptor:
             sql: trace
 
+management:
+  endpoint:
+    health:
+      show-components: always # db, disk, ping 등 추가적인 연결 확인도 할 수 있음. 전부 UP이어야 최종 status가 UP
+  endpoints:
+    web:
+      exposure:
+        include: health # web으로 접속 시 표시할 항목 추가


### PR DESCRIPTION
actuator를 추가해서 health check api를 사용할 수 있도록 했습니다.

요구 사항에선 URI가 /health-check 였는데,
actuator를 사용하면 "/actuator/health" 로 접근해야 합니다 (actuator 부분은 변경 가능)

![image](https://github.com/choorai/excuse-me-backend/assets/24751937/5abe6d3d-cfcd-420d-b07c-318eb7c92f66)

2024.01.14 추가적으로 SecurityConfig에서 /actuator/** 는 permit 해두었고, 나머지는 authenticated 하게 바꾸었습니다.

- close #3 