### PR TITLE
Feature/#25 create lecture

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'io.rest-assured:rest-assured'
 }
 

--- a/src/main/java/choorai/excuseme/global/config/SecurityConfig.java
+++ b/src/main/java/choorai/excuseme/global/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
         });
 
         http.authorizeHttpRequests(configurer ->
-                configurer.requestMatchers("/actuator/**").permitAll()
+                configurer.requestMatchers("/actuator/**", "/error/**").permitAll()
                         .requestMatchers("/members/register", "/members/login").permitAll()
                         .anyRequest().authenticated()
         );

--- a/src/main/java/choorai/excuseme/global/security/CustomUserDetails.java
+++ b/src/main/java/choorai/excuseme/global/security/CustomUserDetails.java
@@ -51,4 +51,8 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    public Member getMember() {
+        return member;
+    }
 }

--- a/src/main/java/choorai/excuseme/lecture/application/LectureService.java
+++ b/src/main/java/choorai/excuseme/lecture/application/LectureService.java
@@ -35,7 +35,7 @@ public class LectureService {
                 .toList();
     }
 
-    public LectureDetailResponse getLectureById(Member member, Long lectureId) {
+    public LectureDetailResponse getLectureById(final Long lectureId) {
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
 

--- a/src/main/java/choorai/excuseme/lecture/application/LectureService.java
+++ b/src/main/java/choorai/excuseme/lecture/application/LectureService.java
@@ -1,0 +1,66 @@
+package choorai.excuseme.lecture.application;
+
+import choorai.excuseme.lecture.domain.Lecture;
+import choorai.excuseme.lecture.domain.dto.LectureDetailResponse;
+import choorai.excuseme.lecture.domain.dto.LectureRequest;
+import choorai.excuseme.lecture.domain.dto.LectureResponse;
+import choorai.excuseme.lecture.domain.repository.LectureRepository;
+import choorai.excuseme.lecture.exception.LectureErrorCode;
+import choorai.excuseme.lecture.exception.LectureException;
+import choorai.excuseme.member.domain.Member;
+import choorai.excuseme.member.exception.MemberErrorCode;
+import choorai.excuseme.member.exception.MemberException;
+import choorai.excuseme.memberlecutre.domain.MemberLecture;
+import choorai.excuseme.memberlecutre.domain.repository.MemberLectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class LectureService {
+
+    private final LectureRepository lectureRepository;
+    private final MemberLectureRepository memberLectureRepository;
+
+    public List<LectureResponse> getLectures() {
+        List<Lecture> lectures = lectureRepository.findAll();
+
+        return lectures.stream()
+                .map(l -> new LectureResponse(l.getId(), l.getName()))
+                .toList();
+    }
+
+    public LectureDetailResponse getLectureById(Member member, Long lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
+
+        return new LectureDetailResponse(
+                lecture.getId(),
+                lecture.getName(),
+                lecture.getThumbnail(),
+                lecture.getVideoUrl()
+        );
+    }
+
+    @Transactional
+    public void watchLecture(final Member member, final Long lectureId, final LectureRequest lectureRequest) {
+
+        if (member == null) {
+            throw new MemberException(MemberErrorCode.USERNAME_NOT_FOUND);
+        }
+
+        Lecture foundLecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
+
+        MemberLecture memberLecture = null;
+        Optional<MemberLecture> optional = memberLectureRepository.findByMemberAndLecture(member, foundLecture);
+        memberLecture = optional.orElseGet(() -> memberLectureRepository.save(new MemberLecture(member, foundLecture)));
+
+        memberLecture.changeProgressStatus(lectureRequest.getProgressStatus());
+    }
+}

--- a/src/main/java/choorai/excuseme/lecture/application/LectureService.java
+++ b/src/main/java/choorai/excuseme/lecture/application/LectureService.java
@@ -60,6 +60,6 @@ public class LectureService {
         MemberLecture memberLecture = memberLectureRepository.findByMemberAndLecture(member, foundLecture)
                 .orElseGet(() -> memberLectureRepository.save(new MemberLecture(member, foundLecture)));
 
-        memberLecture.changeProgressStatus(lectureRequest.getProgressStatus());
+        memberLecture.changeProgressStatus(lectureRequest.progressStatus());
     }
 }

--- a/src/main/java/choorai/excuseme/lecture/application/LectureService.java
+++ b/src/main/java/choorai/excuseme/lecture/application/LectureService.java
@@ -26,7 +26,7 @@ public class LectureService {
     private final MemberLectureRepository memberLectureRepository;
 
     public List<LectureResponse> getLectures() {
-        List<Lecture> lectures = lectureRepository.findAll();
+        final List<Lecture> lectures = lectureRepository.findAll();
 
         return lectures.stream()
                 .map(l -> new LectureResponse(l.getId(), l.getName()))
@@ -34,7 +34,7 @@ public class LectureService {
     }
 
     public LectureDetailResponse getLectureById(final Long lectureId) {
-        Lecture lecture = lectureRepository.findById(lectureId)
+        final Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
 
         return new LectureDetailResponse(
@@ -52,10 +52,10 @@ public class LectureService {
             throw new MemberException(MemberErrorCode.USERNAME_NOT_FOUND);
         }
 
-        Lecture foundLecture = lectureRepository.findById(lectureId)
+        final Lecture foundLecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
 
-        MemberLecture memberLecture = memberLectureRepository.findByMemberAndLecture(member, foundLecture)
+        final MemberLecture memberLecture = memberLectureRepository.findByMemberAndLecture(member, foundLecture)
                 .orElseGet(() -> memberLectureRepository.save(new MemberLecture(member, foundLecture)));
 
         memberLecture.changeProgressStatus(lectureRequest.progressStatus());

--- a/src/main/java/choorai/excuseme/lecture/application/LectureService.java
+++ b/src/main/java/choorai/excuseme/lecture/application/LectureService.java
@@ -57,9 +57,8 @@ public class LectureService {
         Lecture foundLecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
 
-        MemberLecture memberLecture = null;
-        Optional<MemberLecture> optional = memberLectureRepository.findByMemberAndLecture(member, foundLecture);
-        memberLecture = optional.orElseGet(() -> memberLectureRepository.save(new MemberLecture(member, foundLecture)));
+        MemberLecture memberLecture = memberLectureRepository.findByMemberAndLecture(member, foundLecture)
+                .orElseGet(() -> memberLectureRepository.save(new MemberLecture(member, foundLecture)));
 
         memberLecture.changeProgressStatus(lectureRequest.getProgressStatus());
     }

--- a/src/main/java/choorai/excuseme/lecture/application/LectureService.java
+++ b/src/main/java/choorai/excuseme/lecture/application/LectureService.java
@@ -12,12 +12,10 @@ import choorai.excuseme.member.exception.MemberErrorCode;
 import choorai.excuseme.member.exception.MemberException;
 import choorai.excuseme.memberlecutre.domain.MemberLecture;
 import choorai.excuseme.memberlecutre.domain.repository.MemberLectureRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/choorai/excuseme/lecture/domain/Lecture.java
+++ b/src/main/java/choorai/excuseme/lecture/domain/Lecture.java
@@ -1,0 +1,26 @@
+package choorai.excuseme.lecture.domain;
+
+import choorai.excuseme.global.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Lecture extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String thumbnail;
+
+    private String videoUrl;
+}

--- a/src/main/java/choorai/excuseme/lecture/domain/Lecture.java
+++ b/src/main/java/choorai/excuseme/lecture/domain/Lecture.java
@@ -23,4 +23,10 @@ public class Lecture extends BaseEntity {
     private String thumbnail;
 
     private String videoUrl;
+
+    public Lecture(String name, String thumbnail, String videoUrl) {
+        this.name = name;
+        this.thumbnail = thumbnail;
+        this.videoUrl = videoUrl;
+    }
 }

--- a/src/main/java/choorai/excuseme/lecture/domain/dto/LectureDetailResponse.java
+++ b/src/main/java/choorai/excuseme/lecture/domain/dto/LectureDetailResponse.java
@@ -1,0 +1,4 @@
+package choorai.excuseme.lecture.domain.dto;
+
+public record LectureDetailResponse(Long id, String name, String thumbnail, String videoUrl) {
+}

--- a/src/main/java/choorai/excuseme/lecture/domain/dto/LectureRequest.java
+++ b/src/main/java/choorai/excuseme/lecture/domain/dto/LectureRequest.java
@@ -1,10 +1,6 @@
 package choorai.excuseme.lecture.domain.dto;
 
 import choorai.excuseme.memberlecutre.domain.ProgressStatus;
-import lombok.Getter;
 
-@Getter
-public class LectureRequest {
-
-    private ProgressStatus progressStatus;
+public record LectureRequest(ProgressStatus progressStatus) {
 }

--- a/src/main/java/choorai/excuseme/lecture/domain/dto/LectureRequest.java
+++ b/src/main/java/choorai/excuseme/lecture/domain/dto/LectureRequest.java
@@ -1,0 +1,10 @@
+package choorai.excuseme.lecture.domain.dto;
+
+import choorai.excuseme.memberlecutre.domain.ProgressStatus;
+import lombok.Getter;
+
+@Getter
+public class LectureRequest {
+
+    private ProgressStatus progressStatus;
+}

--- a/src/main/java/choorai/excuseme/lecture/domain/dto/LectureResponse.java
+++ b/src/main/java/choorai/excuseme/lecture/domain/dto/LectureResponse.java
@@ -1,0 +1,4 @@
+package choorai.excuseme.lecture.domain.dto;
+
+public record LectureResponse(Long id, String name) {
+}

--- a/src/main/java/choorai/excuseme/lecture/domain/repository/LectureRepository.java
+++ b/src/main/java/choorai/excuseme/lecture/domain/repository/LectureRepository.java
@@ -1,0 +1,7 @@
+package choorai.excuseme.lecture.domain.repository;
+
+import choorai.excuseme.lecture.domain.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+}

--- a/src/main/java/choorai/excuseme/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/choorai/excuseme/lecture/exception/LectureErrorCode.java
@@ -1,0 +1,36 @@
+package choorai.excuseme.lecture.exception;
+
+import choorai.excuseme.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum LectureErrorCode implements ErrorCode {
+
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 입력", "올바르지 않은 패스워드 입니다."),
+    ALREADY_EXIST(HttpStatus.BAD_REQUEST, "잘못된 입력", "이미 존재하는 회원입니다."),
+    LECTURE_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 입력", "해당 수업을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String errorMessage;
+
+    LectureErrorCode(HttpStatus httpStatus, String errorCode, String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/choorai/excuseme/lecture/exception/LectureException.java
+++ b/src/main/java/choorai/excuseme/lecture/exception/LectureException.java
@@ -1,0 +1,18 @@
+package choorai.excuseme.lecture.exception;
+
+import choorai.excuseme.global.exception.CommonException;
+import choorai.excuseme.global.exception.ErrorCode;
+
+import java.util.Map;
+
+public class LectureException extends CommonException {
+
+
+    public LectureException(ErrorCode errorCode, Map<String, Object> additionalInfos) {
+        super(errorCode, additionalInfos);
+    }
+
+    public LectureException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/choorai/excuseme/lecture/exception/LectureException.java
+++ b/src/main/java/choorai/excuseme/lecture/exception/LectureException.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 public class LectureException extends CommonException {
 
-
     public LectureException(ErrorCode errorCode, Map<String, Object> additionalInfos) {
         super(errorCode, additionalInfos);
     }

--- a/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
+++ b/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
@@ -5,13 +5,15 @@ import choorai.excuseme.lecture.domain.dto.LectureDetailResponse;
 import choorai.excuseme.lecture.domain.dto.LectureRequest;
 import choorai.excuseme.lecture.domain.dto.LectureResponse;
 import choorai.excuseme.member.domain.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,13 +23,13 @@ public class LectureController {
 
     @GetMapping("/lectures")
     public ResponseEntity<List<LectureResponse>> getLectures() {
-        List<LectureResponse> lectureResponses = lectureService.getLectures();
+        final List<LectureResponse> lectureResponses = lectureService.getLectures();
         return ResponseEntity.ok(lectureResponses);
     }
 
     @GetMapping("/lectures/{lectureId}")
     public ResponseEntity<LectureDetailResponse> getLectureById(@PathVariable(name = "lectureId") final Long lectureId) {
-        LectureDetailResponse response = lectureService.getLectureById(lectureId);
+        final LectureDetailResponse response = lectureService.getLectureById(lectureId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
+++ b/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
@@ -26,8 +26,8 @@ public class LectureController {
     }
 
     @GetMapping("/lectures/{lectureId}")
-    public ResponseEntity<LectureDetailResponse> getLectureById(@AuthenticationPrincipal(expression = "member") final Member member, @PathVariable(name = "lectureId") final Long lectureId) {
-        LectureDetailResponse response = lectureService.getLectureById(member, lectureId);
+    public ResponseEntity<LectureDetailResponse> getLectureById(@PathVariable(name = "lectureId") final Long lectureId) {
+        LectureDetailResponse response = lectureService.getLectureById(lectureId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
+++ b/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
@@ -22,13 +22,13 @@ public class LectureController {
     @GetMapping("/lectures")
     public ResponseEntity<List<LectureResponse>> getLectures() {
         List<LectureResponse> lectureResponses = lectureService.getLectures();
-        return new ResponseEntity<>(lectureResponses, HttpStatus.OK);
+        return ResponseEntity.ok(lectureResponses);
     }
 
     @GetMapping("/lectures/{lectureId}")
     public ResponseEntity<LectureDetailResponse> getLectureById(@PathVariable(name = "lectureId") final Long lectureId) {
         LectureDetailResponse response = lectureService.getLectureById(lectureId);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/lectures/{lectureId}")

--- a/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
+++ b/src/main/java/choorai/excuseme/lecture/ui/LectureController.java
@@ -1,0 +1,40 @@
+package choorai.excuseme.lecture.ui;
+
+import choorai.excuseme.lecture.application.LectureService;
+import choorai.excuseme.lecture.domain.dto.LectureDetailResponse;
+import choorai.excuseme.lecture.domain.dto.LectureRequest;
+import choorai.excuseme.lecture.domain.dto.LectureResponse;
+import choorai.excuseme.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class LectureController {
+
+    private final LectureService lectureService;
+
+    @GetMapping("/lectures")
+    public ResponseEntity<List<LectureResponse>> getLectures() {
+        List<LectureResponse> lectureResponses = lectureService.getLectures();
+        return new ResponseEntity<>(lectureResponses, HttpStatus.OK);
+    }
+
+    @GetMapping("/lectures/{lectureId}")
+    public ResponseEntity<LectureDetailResponse> getLectureById(@AuthenticationPrincipal(expression = "member") final Member member, @PathVariable(name = "lectureId") final Long lectureId) {
+        LectureDetailResponse response = lectureService.getLectureById(member, lectureId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/lectures/{lectureId}")
+    public void watchLecture(@AuthenticationPrincipal(expression = "member") final Member member,
+                             @PathVariable(name = "lectureId") final Long lectureId,
+                             @RequestBody final LectureRequest lectureRequest) {
+        lectureService.watchLecture(member, lectureId, lectureRequest);
+    }
+}

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
@@ -26,7 +26,6 @@ public class MemberLecture extends BaseEntity {
     private Lecture lecture;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(255) NOT NULL")
     private ProgressStatus progressStatus;
 
     public MemberLecture(final Member member, final Lecture lecture) {

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
@@ -17,11 +17,11 @@ public class MemberLecture extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_member"))
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_lecture"))
     private Lecture lecture;
 

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
@@ -1,0 +1,30 @@
+package choorai.excuseme.memberlecutre.domain;
+
+import choorai.excuseme.global.domain.BaseEntity;
+import choorai.excuseme.lecture.domain.Lecture;
+import choorai.excuseme.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class MemberLecture extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_member"))
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "lecture_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_lecture"))
+    private Lecture lecture;
+
+    @Column(columnDefinition = "VARCHAR(255) NOT NULL")
+    private ProgressStatus progressStatus;
+}

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/MemberLecture.java
@@ -25,6 +25,17 @@ public class MemberLecture extends BaseEntity {
     @JoinColumn(name = "lecture_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_lecture"))
     private Lecture lecture;
 
+    @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(255) NOT NULL")
     private ProgressStatus progressStatus;
+
+    public MemberLecture(final Member member, final Lecture lecture) {
+        this.member = member;
+        this.lecture = lecture;
+        this.progressStatus = ProgressStatus.NOT_WATCHED;
+    }
+
+    public void changeProgressStatus(final ProgressStatus progressStatus) {
+        this.progressStatus = progressStatus;
+    }
 }

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/ProgressStatus.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/ProgressStatus.java
@@ -1,0 +1,7 @@
+package choorai.excuseme.memberlecutre.domain;
+
+public enum ProgressStatus {
+    WATCHING,
+    COMPLETED,
+    NOT_WATCHED
+}

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/repository/MemberLectureRepository.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/repository/MemberLectureRepository.java
@@ -14,12 +14,5 @@ public interface MemberLectureRepository extends JpaRepository<MemberLecture, Lo
 
     List<MemberLecture> findByMember(Member member);
 
-//    @Query(value = """
-//            SELECT mr FROM MemberLecture mr
-//            RIGHT JOIN
-//            WHERE memb
-//            """)
-//    Optional<MemberLecture> findByMemberIdAndLectureId(@Param("memberId") Long memberId, @Param("lectureId") Long lectureId);
-
     Optional<MemberLecture> findByMemberAndLecture(final Member member, final Lecture lecture);
 }

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/repository/MemberLectureRepository.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/repository/MemberLectureRepository.java
@@ -1,7 +1,25 @@
 package choorai.excuseme.memberlecutre.domain.repository;
 
+import choorai.excuseme.lecture.domain.Lecture;
+import choorai.excuseme.member.domain.Member;
 import choorai.excuseme.memberlecutre.domain.MemberLecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MemberLectureRepository extends JpaRepository<MemberLecture, Long> {
+
+    List<MemberLecture> findByMember(Member member);
+
+//    @Query(value = """
+//            SELECT mr FROM MemberLecture mr
+//            RIGHT JOIN
+//            WHERE memb
+//            """)
+//    Optional<MemberLecture> findByMemberIdAndLectureId(@Param("memberId") Long memberId, @Param("lectureId") Long lectureId);
+
+    Optional<MemberLecture> findByMemberAndLecture(final Member member, final Lecture lecture);
 }

--- a/src/main/java/choorai/excuseme/memberlecutre/domain/repository/MemberLectureRepository.java
+++ b/src/main/java/choorai/excuseme/memberlecutre/domain/repository/MemberLectureRepository.java
@@ -1,0 +1,7 @@
+package choorai.excuseme.memberlecutre.domain.repository;
+
+import choorai.excuseme.memberlecutre.domain.MemberLecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberLectureRepository extends JpaRepository<MemberLecture, Long> {
+}

--- a/src/main/resources/db/migration/V20240218_1720__create_lecture.sql
+++ b/src/main/resources/db/migration/V20240218_1720__create_lecture.sql
@@ -1,0 +1,9 @@
+CREATE TABLE lecture
+(
+    id         BIGINT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    name       VARCHAR(255)          NOT NULL,
+    thumbnail  VARCHAR(255)          NOT NULL,
+    video_url  VARCHAR(255)          NOT NULL,
+    created_at DATETIME,
+    updated_at DATETIME
+);

--- a/src/main/resources/db/migration/V20240218_1720__create_lecture.sql
+++ b/src/main/resources/db/migration/V20240218_1720__create_lecture.sql
@@ -5,5 +5,7 @@ CREATE TABLE lecture
     thumbnail  VARCHAR(255)          NOT NULL,
     video_url  VARCHAR(255)          NOT NULL,
     created_at DATETIME,
-    updated_at DATETIME
+    updated_at DATETIME,
+
+    INDEX idx_name (name)
 );

--- a/src/main/resources/db/migration/V20240218_1725__create_member_lecture.sql
+++ b/src/main/resources/db/migration/V20240218_1725__create_member_lecture.sql
@@ -3,7 +3,7 @@ CREATE TABLE member_lecture
     id              BIGINT AUTO_INCREMENT NOT NULL PRIMARY KEY,
     member_id       BIGINT                NOT NULL,
     lecture_id      BIGINT                NOT NULL,
-    progress_status VARCHAR(255)          NOT NULL,
+    progress_status ENUM('NOT_WATCHED', 'WATCHING', 'COMPLETED'),
     created_at      DATETIME,
     updated_at      DATETIME,
 

--- a/src/main/resources/db/migration/V20240218_1725__create_member_lecture.sql
+++ b/src/main/resources/db/migration/V20240218_1725__create_member_lecture.sql
@@ -8,5 +8,7 @@ CREATE TABLE member_lecture
     updated_at      DATETIME,
 
     CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member (id),
-    CONSTRAINT fk_lecture FOREIGN KEY (lecture_id) REFERENCES lecture (id)
+    CONSTRAINT fk_lecture FOREIGN KEY (lecture_id) REFERENCES lecture (id),
+
+    INDEX idx_member_lecture_id (member_id, lecture_id)
 );

--- a/src/main/resources/db/migration/V20240218_1725__create_member_lecture.sql
+++ b/src/main/resources/db/migration/V20240218_1725__create_member_lecture.sql
@@ -1,0 +1,12 @@
+CREATE TABLE member_lecture
+(
+    id              BIGINT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    member_id       BIGINT                NOT NULL,
+    lecture_id      BIGINT                NOT NULL,
+    progress_status VARCHAR(255)          NOT NULL,
+    created_at      DATETIME,
+    updated_at      DATETIME,
+
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member (id),
+    CONSTRAINT fk_lecture FOREIGN KEY (lecture_id) REFERENCES lecture (id)
+);

--- a/src/test/java/choorai/excuseme/lecture/ui/LectureControllerTest.java
+++ b/src/test/java/choorai/excuseme/lecture/ui/LectureControllerTest.java
@@ -1,0 +1,96 @@
+package choorai.excuseme.lecture.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import choorai.excuseme.global.security.JwtProvider;
+import choorai.excuseme.lecture.domain.Lecture;
+import choorai.excuseme.lecture.domain.dto.LectureRequest;
+import choorai.excuseme.lecture.domain.repository.LectureRepository;
+import choorai.excuseme.member.domain.Member;
+import choorai.excuseme.member.domain.Role;
+import choorai.excuseme.member.domain.repository.MemberRepository;
+import choorai.excuseme.memberlecutre.domain.MemberLecture;
+import choorai.excuseme.memberlecutre.domain.ProgressStatus;
+import choorai.excuseme.memberlecutre.domain.repository.MemberLectureRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class LectureControllerTest {
+
+    @LocalServerPort
+    private int port;
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private LectureRepository lectureRepository;
+
+    @Autowired
+    private MemberLectureRepository memberLectureRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @AfterEach
+    void afterEach() {
+        memberLectureRepository.deleteAll();
+        lectureRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("강의를 시청한다.")
+    void watch_lecture() throws Exception {
+        // given
+        final Member normalMember = Member.createNormalMember("excuseme", passwordEncoder.encode("excuseme"));
+        memberRepository.save(normalMember);
+
+        final Lecture lecture = new Lecture("lecture1", "thumbnail", "videoUrl");
+        lectureRepository.save(lecture);
+
+        final String accessToken = jwtProvider.createToken("excuseme", Role.USER);
+        final LectureRequest lectureRequest = new LectureRequest(ProgressStatus.COMPLETED);
+
+        // when
+        RestAssured
+            .given()
+            .headers("Authorization", "Bearer " + accessToken)
+            .body(lectureRequest).contentType(ContentType.JSON)
+            .when().post("/lectures/" + lecture.getId())
+            .then().statusCode(HttpStatus.OK.value());
+
+        // then
+        final Optional<MemberLecture> registeredMemberLecture = memberLectureRepository.findByMemberAndLecture(
+            normalMember,
+            lecture);
+
+        assertThat(registeredMemberLecture).isNotEmpty();
+
+        final MemberLecture memberLecture = registeredMemberLecture.get();
+
+        assertThat(memberLecture.getProgressStatus()).isEqualTo(ProgressStatus.COMPLETED);
+    }
+}

--- a/src/test/java/choorai/excuseme/lecture/ui/LectureControllerTest.java
+++ b/src/test/java/choorai/excuseme/lecture/ui/LectureControllerTest.java
@@ -12,27 +12,19 @@ import choorai.excuseme.member.domain.repository.MemberRepository;
 import choorai.excuseme.memberlecutre.domain.MemberLecture;
 import choorai.excuseme.memberlecutre.domain.ProgressStatus;
 import choorai.excuseme.memberlecutre.domain.repository.MemberLectureRepository;
+import choorai.excuseme.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.test.context.support.WithMockUser;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-class LectureControllerTest {
+class LectureControllerTest extends AcceptanceTest {
 
-    @LocalServerPort
-    private int port;
     @Autowired
     private JwtProvider jwtProvider;
 
@@ -48,11 +40,6 @@ class LectureControllerTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
-
     @AfterEach
     void afterEach() {
         memberLectureRepository.deleteAll();
@@ -61,7 +48,6 @@ class LectureControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = "USER")
     @DisplayName("강의를 시청한다.")
     void watch_lecture() throws Exception {
         // given
@@ -87,10 +73,7 @@ class LectureControllerTest {
             normalMember,
             lecture);
 
-        assertThat(registeredMemberLecture).isNotEmpty();
-
         final MemberLecture memberLecture = registeredMemberLecture.get();
-
         assertThat(memberLecture.getProgressStatus()).isEqualTo(ProgressStatus.COMPLETED);
     }
 }


### PR DESCRIPTION
- close #25 

수업 도메인을 구성하고, 조회 및 시청하기 기능을 구현했습니다.

엔티티 구성은 다음과 같습니다.

<img width="332" alt="image" src="https://github.com/choorai/excuse-me-backend/assets/24751937/628be856-0f10-42f9-8c29-a94a0d365a3e">

그리고 API는 다음과 같습니다.

- GET /lectures:  수업 리스트 전체 조회
<img width="328" alt="image" src="https://github.com/choorai/excuse-me-backend/assets/24751937/cb3ad157-32dc-4598-8b3c-24e23386b836">

- GET /lectures/{lectureId}: 수업 상세 조회 
<img width="499" alt="image" src="https://github.com/choorai/excuse-me-backend/assets/24751937/23795202-7db9-4f17-adf2-c7268e1a9ec8">

- POST /lectures/{lectureId}: 시청하기
<img width="581" alt="image" src="https://github.com/choorai/excuse-me-backend/assets/24751937/e72bc670-8de4-4b36-accf-4c33877e45a8">

고민 사항으론 전체 조회나 상세 조회에서 수업 별로 사용자 본인의 시청 상황을 같이 첨부해주는게, UI에서 표시해 줄때 좋은거 같은데
해줄지 말지 고민하다가 우선 안 보이게 해서 올렸습니다. 보시고 의견 주시면 감사하겠습니다! :)
