### PR TITLE
Feature/#32 test user register

### DIFF
--- a/src/main/java/choorai/excuseme/member/domain/UserName.java
+++ b/src/main/java/choorai/excuseme/member/domain/UserName.java
@@ -18,8 +18,7 @@ import lombok.NoArgsConstructor;
 public class UserName {
 
     // 이메일 형식의 정규식
-    private static final Pattern USERNAME_FORMAT = Pattern.compile(
-        "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$");
+    private static final Pattern USERNAME_FORMAT = Pattern.compile("[a-z0-9]+@[a-z]+\\.[a-z]{2,3}");
 
     @Column(name = "username", nullable = false)
     private String value;

--- a/src/test/java/choorai/excuseme/member/ui/MemberControllerTest.java
+++ b/src/test/java/choorai/excuseme/member/ui/MemberControllerTest.java
@@ -124,6 +124,34 @@ class MemberControllerTest extends AcceptanceTest {
         });
     }
 
+    @DisplayName("11자리 숫자가 아닌 전화번호를 입력받으면 예외를 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"abcdefghijk", "!@#$%^&*!@#", "123456789012", "1234567890"})
+    void fail_register_with_wrongPhoneNumber(String phoneNumber) {
+        // given
+        final SignRequest request = new SignRequest("a@email.com",
+                                                    "password1@",
+                                                    "이름",
+                                                    "MEN",
+                                                    "20240219",
+                                                    phoneNumber);
+
+        // when
+        final CustomExceptionResponse result = RestAssured
+            .given().body(request).contentType(ContentType.JSON)
+            .when().post("/members/register")
+            .then().statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract().body().as(CustomExceptionResponse.class);
+
+        // then
+        final MemberErrorCode expect = MemberErrorCode.WRONG_PHONE_NUMBER;
+
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(result.code()).isEqualTo(expect.getCode());
+            softAssertions.assertThat(result.errorMessage()).isEqualTo(expect.getMessage());
+        });
+    }
+
     @DisplayName("일반 로그인을 수행한다.")
     @Test
     void login_member() {


### PR DESCRIPTION
### 작업한 내용

member 일반회원 가입과 관련된 인수(시나리오) 테스트 코드를 작성했습니다.

- 일반 회원가입 성공 검증 구체화
- 일반 회원가입 실패 테스트 추가
    -  입력받은 id가 이메일 형식이 아닌 경우
    -  입력받은 비밀번호가 영어문자, 숫자, 특수문자를 모두 포함한 6자이상 20자이하가 아닌 경우
    -  전화번호가 숫자 11자리가 아닌 경우

현재 위와 관련된 테스트 코드를 작성했습니다.
 혹시 빼먹은 부분이나 잘못된 점있으면 리뷰 부탁드립니다🙇‍♂️

- close #32 